### PR TITLE
Add VL53L0X driver example for ESP32-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Below is short explanation of remaining files in the project folder.
 ```
 Additionally, the sample project contains Makefile and component.mk files, used for the legacy Make based build system. 
 They are not used or needed when building with CMake and idf.py.
+
+## VL53L0X Example
+
+This project demonstrates how to read distance measurements from a VL53L0X sensor using an ESP32-S3. The sensor is connected via the I2C bus. Default pins are GPIO18 (SDA) and GPIO19 (SCL). The `vl53l0x` component initializes the sensor and provides a helper function to retrieve the distance in millimetres.
+
+Build the project with `idf.py build` and flash it with `idf.py flash`. After reset, the application continuously prints the measured distance to the serial console.

--- a/components/vl53l0x/CMakeLists.txt
+++ b/components/vl53l0x/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "vl53l0x.c" \
+                       INCLUDE_DIRS ".")

--- a/components/vl53l0x/README.md
+++ b/components/vl53l0x/README.md
@@ -1,0 +1,12 @@
+# VL53L0X component
+
+This component provides a minimal driver for the VL53L0X time-of-flight sensor using the ESP-IDF I2C master driver. It exposes two functions:
+
+```c
+esp_err_t vl53l0x_init(i2c_port_t port);
+int vl53l0x_read_range_mm(i2c_port_t port);
+```
+
+`vl53l0x_init` performs a basic initialization sequence for the sensor. `vl53l0x_read_range_mm` triggers a single measurement and returns the distance in millimetres, or `-1` on error.
+
+The component is automatically included when building the example project in this repository.

--- a/components/vl53l0x/vl53l0x.c
+++ b/components/vl53l0x/vl53l0x.c
@@ -1,0 +1,90 @@
+#include "vl53l0x.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+#define TAG "VL53L0X"
+
+static esp_err_t write_reg(i2c_port_t port, uint8_t reg, uint8_t value)
+{
+    uint8_t data[2] = {reg, value};
+    return i2c_master_write_to_device(port, VL53L0X_I2C_ADDR, data, sizeof(data), pdMS_TO_TICKS(100));
+}
+
+static esp_err_t read_reg(i2c_port_t port, uint8_t reg, uint8_t *value)
+{
+    return i2c_master_write_read_device(port, VL53L0X_I2C_ADDR, &reg, 1, value, 1, pdMS_TO_TICKS(100));
+}
+
+static esp_err_t read_reg16(i2c_port_t port, uint8_t reg, uint16_t *value)
+{
+    uint8_t buf[2];
+    esp_err_t err = i2c_master_write_read_device(port, VL53L0X_I2C_ADDR, &reg, 1, buf, 2, pdMS_TO_TICKS(100));
+    if (err == ESP_OK) {
+        *value = ((uint16_t)buf[0] << 8) | buf[1];
+    }
+    return err;
+}
+
+esp_err_t vl53l0x_init(i2c_port_t port)
+{
+    // simple check for device presence
+    uint8_t id = 0;
+    esp_err_t err = read_reg(port, 0xC0, &id); // IDENTIFICATION_MODEL_ID
+    if (err != ESP_OK) {
+        return err;
+    }
+    if (id != 0xEE) {
+        ESP_LOGE(TAG, "Unexpected model id: 0x%02x", id);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    // Set I2C standard mode
+    err |= write_reg(port, 0x88, 0x00);
+
+    // minimal init sequence based on ST API
+    err |= write_reg(port, 0x80, 0x01);
+    err |= write_reg(port, 0xFF, 0x01);
+    err |= write_reg(port, 0x00, 0x00);
+    uint8_t stop_variable;
+    read_reg(port, 0x91, &stop_variable);
+    err |= write_reg(port, 0x00, 0x01);
+    err |= write_reg(port, 0xFF, 0x00);
+    err |= write_reg(port, 0x80, 0x00);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    return err;
+}
+
+int vl53l0x_read_range_mm(i2c_port_t port)
+{
+    esp_err_t err = write_reg(port, 0x00, 0x01); // SYSRANGE_START
+    if (err != ESP_OK) {
+        return -1;
+    }
+    // wait for start bit to clear
+    uint8_t status;
+    do {
+        err = read_reg(port, 0x00, &status);
+        if (err != ESP_OK) return -1;
+    } while (status & 0x01);
+
+    // polling for data ready
+    uint8_t ready = 0;
+    int timeout = 20;
+    while (!(ready & 0x07) && timeout--) {
+        err = read_reg(port, 0x13, &ready); // RESULT_INTERRUPT_STATUS
+        if (err != ESP_OK) return -1;
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (!(ready & 0x07)) {
+        ESP_LOGE(TAG, "timeout waiting for data ready");
+        return -1;
+    }
+
+    uint16_t range;
+    err = read_reg16(port, 0x14 + 10, &range); // RESULT_RANGE_STATUS + 10
+    if (err != ESP_OK) return -1;
+
+    write_reg(port, 0x0B, 0x01); // SYSTEM_INTERRUPT_CLEAR
+    return range;
+}

--- a/components/vl53l0x/vl53l0x.h
+++ b/components/vl53l0x/vl53l0x.h
@@ -1,0 +1,20 @@
+#ifndef VL53L0X_H
+#define VL53L0X_H
+
+#include "driver/i2c.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VL53L0X_I2C_ADDR 0x29
+
+esp_err_t vl53l0x_init(i2c_port_t port);
+int vl53l0x_read_range_mm(i2c_port_t port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VL53L0X_H

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES vl53l0x)

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,43 @@
 #include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
+#include "vl53l0x.h"
+
+#define I2C_MASTER_SCL_IO 19
+#define I2C_MASTER_SDA_IO 18
+#define I2C_MASTER_NUM I2C_NUM_0
+#define I2C_MASTER_FREQ_HZ 400000
+
+static const char *TAG = "MAIN";
+
+static esp_err_t i2c_master_init(void)
+{
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = I2C_MASTER_FREQ_HZ,
+    };
+    ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &conf));
+    return i2c_driver_install(I2C_MASTER_NUM, conf.mode, 0, 0, 0);
+}
 
 void app_main(void)
 {
+    ESP_ERROR_CHECK(i2c_master_init());
+    ESP_ERROR_CHECK(vl53l0x_init(I2C_MASTER_NUM));
 
+    while (1) {
+        int dist = vl53l0x_read_range_mm(I2C_MASTER_NUM);
+        if (dist >= 0) {
+            ESP_LOGI(TAG, "Distance: %d mm", dist);
+        } else {
+            ESP_LOGE(TAG, "Read failed");
+        }
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
 }


### PR DESCRIPTION
## Summary
- implement simple VL53L0X component for ESP-IDF
- use component in main app to print distance measurements
- document new example in README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6b5ed33483239ae178a46a4925a5