### PR TITLE
Add VL53L0X driver using new I2C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(project-name)
+project(vl53l0x_example)

--- a/README.md
+++ b/README.md
@@ -30,3 +30,23 @@ Below is short explanation of remaining files in the project folder.
 ```
 Additionally, the sample project contains Makefile and component.mk files, used for the legacy Make based build system. 
 They are not used or needed when building with CMake and idf.py.
+
+## VL53L0X Example
+
+This project demonstrates how to read distance measurements from a VL53L0X sensor using an ESP32-S3. The sensor is connected via the I2C bus using the new `esp_driver_i2c` master API. Default pins are GPIO18 (SDA) and GPIO19 (SCL). The `vl53l0x` component initializes the sensor and provides a helper function to retrieve the distance in millimetres.
+
+Make sure the ESP-IDF tools are installed and the target is set to the ESP32-S3:
+
+```bash
+idf.py set-target esp32s3
+idf.py menuconfig  # optional, generates sdkconfig
+```
+
+Then build and flash the project with:
+
+```bash
+idf.py build
+idf.py flash
+```
+
+After reset, the application continuously prints the measured distance to the serial console.

--- a/components/vl53l0x/CMakeLists.txt
+++ b/components/vl53l0x/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "vl53l0x.c"
+    INCLUDE_DIRS "."
+    REQUIRES esp_driver_i2c
+)

--- a/components/vl53l0x/README.md
+++ b/components/vl53l0x/README.md
@@ -1,0 +1,12 @@
+# VL53L0X component
+
+This component provides a minimal driver for the VL53L0X time-of-flight sensor using the ESP-IDF `esp_driver_i2c` master driver. It exposes two functions:
+
+```c
+esp_err_t vl53l0x_init(i2c_master_dev_handle_t dev);
+int vl53l0x_read_range_mm(i2c_master_dev_handle_t dev);
+```
+
+`vl53l0x_init` performs a basic initialization sequence for the sensor. `vl53l0x_read_range_mm` triggers a single measurement and returns the distance in millimetres, or `-1` on error.
+
+The component is automatically included when building the example project in this repository.

--- a/components/vl53l0x/vl53l0x.c
+++ b/components/vl53l0x/vl53l0x.c
@@ -1,0 +1,92 @@
+#include "vl53l0x.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+#define TAG "VL53L0X"
+
+static const int I2C_TIMEOUT_MS = 100;
+
+static esp_err_t write_reg(i2c_master_dev_handle_t dev, uint8_t reg, uint8_t value)
+{
+    uint8_t data[2] = {reg, value};
+    return i2c_master_transmit(dev, data, sizeof(data), I2C_TIMEOUT_MS / portTICK_PERIOD_MS);
+}
+
+static esp_err_t read_reg(i2c_master_dev_handle_t dev, uint8_t reg, uint8_t *value)
+{
+    return i2c_master_transmit_receive(dev, &reg, 1, value, 1, I2C_TIMEOUT_MS / portTICK_PERIOD_MS);
+}
+
+static esp_err_t read_reg16(i2c_master_dev_handle_t dev, uint8_t reg, uint16_t *value)
+{
+    uint8_t buf[2];
+    esp_err_t err = i2c_master_transmit_receive(dev, &reg, 1, buf, 2, I2C_TIMEOUT_MS / portTICK_PERIOD_MS);
+    if (err == ESP_OK) {
+        *value = ((uint16_t)buf[0] << 8) | buf[1];
+    }
+    return err;
+}
+
+esp_err_t vl53l0x_init(i2c_master_dev_handle_t dev)
+{
+    // simple check for device presence
+    uint8_t id = 0;
+    esp_err_t err = read_reg(dev, 0xC0, &id); // IDENTIFICATION_MODEL_ID
+    if (err != ESP_OK) {
+        return err;
+    }
+    if (id != 0xEE) {
+        ESP_LOGE(TAG, "Unexpected model id: 0x%02x", id);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    // Set I2C standard mode
+    err |= write_reg(dev, 0x88, 0x00);
+
+    // minimal init sequence based on ST API
+    err |= write_reg(dev, 0x80, 0x01);
+    err |= write_reg(dev, 0xFF, 0x01);
+    err |= write_reg(dev, 0x00, 0x00);
+    uint8_t stop_variable;
+    read_reg(dev, 0x91, &stop_variable);
+    err |= write_reg(dev, 0x00, 0x01);
+    err |= write_reg(dev, 0xFF, 0x00);
+    err |= write_reg(dev, 0x80, 0x00);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    return err;
+}
+
+int vl53l0x_read_range_mm(i2c_master_dev_handle_t dev)
+{
+    esp_err_t err = write_reg(dev, 0x00, 0x01); // SYSRANGE_START
+    if (err != ESP_OK) {
+        return -1;
+    }
+    // wait for start bit to clear
+    uint8_t status;
+    do {
+        err = read_reg(dev, 0x00, &status);
+        if (err != ESP_OK) return -1;
+    } while (status & 0x01);
+
+    // polling for data ready
+    uint8_t ready = 0;
+    int timeout = 20;
+    while (!(ready & 0x07) && timeout--) {
+        err = read_reg(dev, 0x13, &ready); // RESULT_INTERRUPT_STATUS
+        if (err != ESP_OK) return -1;
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (!(ready & 0x07)) {
+        ESP_LOGE(TAG, "timeout waiting for data ready");
+        return -1;
+    }
+
+    uint16_t range;
+    err = read_reg16(dev, 0x14 + 10, &range); // RESULT_RANGE_STATUS + 10
+    if (err != ESP_OK) return -1;
+
+    write_reg(dev, 0x0B, 0x01); // SYSTEM_INTERRUPT_CLEAR
+    return range;
+}

--- a/components/vl53l0x/vl53l0x.h
+++ b/components/vl53l0x/vl53l0x.h
@@ -1,0 +1,20 @@
+#ifndef VL53L0X_H
+#define VL53L0X_H
+
+#include "driver/i2c_master.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VL53L0X_I2C_ADDR 0x29
+
+esp_err_t vl53l0x_init(i2c_master_dev_handle_t dev);
+int vl53l0x_read_range_mm(i2c_master_dev_handle_t dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VL53L0X_H

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES vl53l0x esp_driver_i2c)

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,51 @@
 #include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/i2c_master.h"
+#include "esp_log.h"
+#include "vl53l0x.h"
+
+#define I2C_MASTER_SCL_IO 19
+#define I2C_MASTER_SDA_IO 18
+#define I2C_MASTER_PORT 0
+#define I2C_MASTER_FREQ_HZ 400000
+
+static const char *TAG = "MAIN";
+
+static void i2c_master_init(i2c_master_bus_handle_t *bus, i2c_master_dev_handle_t *dev)
+{
+    i2c_master_bus_config_t bus_config = {
+        .i2c_port = I2C_MASTER_PORT,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags = { .enable_internal_pullup = true },
+    };
+    ESP_ERROR_CHECK(i2c_new_master_bus(&bus_config, bus));
+
+    i2c_device_config_t dev_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = VL53L0X_I2C_ADDR,
+        .scl_speed_hz = I2C_MASTER_FREQ_HZ,
+    };
+    ESP_ERROR_CHECK(i2c_master_bus_add_device(*bus, &dev_config, dev));
+}
 
 void app_main(void)
 {
+    i2c_master_bus_handle_t bus;
+    i2c_master_dev_handle_t dev;
+    i2c_master_init(&bus, &dev);
+    ESP_ERROR_CHECK(vl53l0x_init(dev));
 
+    while (1) {
+        int dist = vl53l0x_read_range_mm(dev);
+        if (dist >= 0) {
+            ESP_LOGI(TAG, "Distance: %d mm", dist);
+        } else {
+            ESP_LOGE(TAG, "Read failed");
+        }
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
 }


### PR DESCRIPTION
## Summary
- use the `esp_driver_i2c` component for VL53L0X communication
- adjust component and example to work with `i2c_master.h`
- document the new driver usage in the README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6b5ed33483239ae178a46a4925a5