### PR TITLE
Add VL53L0X driver component

### DIFF
--- a/components/vl53l0x/CMakeLists.txt
+++ b/components/vl53l0x/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "vl53l0x.c"
+                       INCLUDE_DIRS "include" "core/inc")

--- a/components/vl53l0x/include/vl53l0x.h
+++ b/components/vl53l0x/include/vl53l0x.h
@@ -1,0 +1,20 @@
+#ifndef VL53L0X_H
+#define VL53L0X_H
+
+#include <driver/i2c_master.h>
+#include <esp_err.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VL53L0X_I2C_ADDR 0x29
+
+esp_err_t vl53l0x_init(i2c_master_dev_handle_t dev);
+int vl53l0x_read_range_mm(i2c_master_dev_handle_t dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // VL53L0X_H

--- a/components/vl53l0x/vl53l0x.c
+++ b/components/vl53l0x/vl53l0x.c
@@ -1,0 +1,89 @@
+#include "vl53l0x.h"
+#include <string.h>
+#include <stdlib.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+static esp_err_t write_reg(i2c_master_dev_handle_t dev, uint16_t reg, uint8_t val)
+{
+    uint8_t buf[3] = { reg >> 8, reg & 0xFF, val };
+    return i2c_master_transmit(dev, buf, sizeof(buf), -1);
+}
+
+static esp_err_t write_multi(i2c_master_dev_handle_t dev, uint16_t reg, const uint8_t *data, size_t len)
+{
+    uint8_t *buf = malloc(len + 2);
+    if (!buf) return ESP_ERR_NO_MEM;
+    buf[0] = reg >> 8;
+    buf[1] = reg & 0xFF;
+    memcpy(buf + 2, data, len);
+    esp_err_t err = i2c_master_transmit(dev, buf, len + 2, -1);
+    free(buf);
+    return err;
+}
+
+static esp_err_t read_reg(i2c_master_dev_handle_t dev, uint16_t reg, uint8_t *val)
+{
+    uint8_t regbuf[2] = { reg >> 8, reg & 0xFF };
+    return i2c_master_transmit_receive(dev, regbuf, sizeof(regbuf), val, 1, -1);
+}
+
+static esp_err_t read_reg16(i2c_master_dev_handle_t dev, uint16_t reg, uint16_t *val)
+{
+    uint8_t regbuf[2] = { reg >> 8, reg & 0xFF };
+    uint8_t data[2];
+    esp_err_t err = i2c_master_transmit_receive(dev, regbuf, sizeof(regbuf), data, 2, -1);
+    if (err == ESP_OK) {
+        *val = ((uint16_t)data[0] << 8) | data[1];
+    }
+    return err;
+}
+
+#include "core/inc/vl53l0x_tuning.h"
+
+esp_err_t vl53l0x_init(i2c_master_dev_handle_t dev)
+{
+    // Load default tuning settings from ST header
+    for (size_t i = 0; i + 2 < sizeof(DefaultTuningSettings); i += 3) {
+        uint8_t type = DefaultTuningSettings[i];
+        uint8_t reg_high = DefaultTuningSettings[i + 1];
+        uint8_t val = DefaultTuningSettings[i + 2];
+        if (type == 0 && reg_high == 0 && val == 0) {
+            break;
+        }
+        uint16_t reg = ((uint16_t)type << 8) | reg_high;
+        esp_err_t err = write_reg(dev, reg, val);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    // start continuous ranging
+    return write_reg(dev, 0x000, 0x01);
+}
+
+int vl53l0x_read_range_mm(i2c_master_dev_handle_t dev)
+{
+    uint8_t status = 0;
+    int timeout = 20;
+    while (timeout--) {
+        if (read_reg(dev, 0x0013, &status) != ESP_OK) {
+            return -1;
+        }
+        if (status & 0x07) {
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (!(status & 0x07)) {
+        return -1;
+    }
+
+    uint16_t range = 0;
+    if (read_reg16(dev, 0x0014 + 10, &range) != ESP_OK) {
+        return -1;
+    }
+
+    write_reg(dev, 0x0B, 0x01); // clear interrupt
+    return range;
+}


### PR DESCRIPTION
## Summary
- add minimal VL53L0X driver component using esp-idf I2C master API
- expose `vl53l0x_init` and `vl53l0x_read_range_mm`
- load ST default tuning settings and start continuous ranging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d54e04edc8323a7fdee96003ff625